### PR TITLE
fix: #3 Crash with Lithium's Sleeping Block Entities

### DIFF
--- a/src/main/java/block/event/separator/mixin/client/LevelMixin.java
+++ b/src/main/java/block/event/separator/mixin/client/LevelMixin.java
@@ -51,6 +51,9 @@ public class LevelMixin implements ILevel {
 			TickingBlockEntity ticker = blockEntityTickers.get(i);
 
 			BlockPos pos = ticker.getPos();
+			if (pos == null) {
+				continue;
+			}
 			long l = ChunkPos.asLong(pos);
 
 			if (!shouldTickBlocksAt(l)) {


### PR DESCRIPTION
This change is not tested, but it is plausible that this fixes the issue https://github.com/SpaceWalkerRS/block-event-separator/issues/3